### PR TITLE
v1.0.8

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -47,11 +47,13 @@ impl DueDateType {
 pub enum SearchResultType {
     Project,
     Task,
+    Step,
     Note,
     JournalEntry,
     Achievement,
     Lore,
     ChronicleEntry,
+    Milestone,
 }
 
 impl SearchResultType {
@@ -59,11 +61,13 @@ impl SearchResultType {
         match self {
             SearchResultType::Project => "Project",
             SearchResultType::Task => "Task",
+            SearchResultType::Step => "Step",
             SearchResultType::Note => "Note",
             SearchResultType::JournalEntry => "Journal",
             SearchResultType::Achievement => "Achievement",
             SearchResultType::Lore => "Lore",
             SearchResultType::ChronicleEntry => "Chronicle",
+            SearchResultType::Milestone => "Milestone",
         }
     }
 }
@@ -542,6 +546,10 @@ pub struct App {
     pub audio_player: crate::audio::AudioPlayer,
     pub selected_soundscape_idx: usize,
     pub selected_focus_soundscape_idx: usize, // 0 = None (Silent), 1..=SOUNDSCAPES.len() = specific soundscape
+
+    // Media Player via MPRIS
+    pub mpris_now_playing: Option<crate::audio::mpris_player::NowPlaying>,
+    pub mpris_last_poll: std::time::Instant,
 
     // Stage 5A Sync & Identity Fields — cripto y sincronización con el servidor
     pub identity: crate::services::identity::Identity,
@@ -1709,6 +1717,10 @@ impl App {
             prologue_next_is_onboarding: false,
             prologue_delay_ticks: 0,
             prologue_skip_checked: false,
+
+            // Media Player via MPRIS
+            mpris_now_playing: None,
+            mpris_last_poll: std::time::Instant::now(),
         };
 
         app.reload_data()?;
@@ -2045,6 +2057,16 @@ impl App {
             return Ok(());
         }
 
+        // "/" abre Search Everywhere desde cualquier pantalla
+        if key.code == KeyCode::Char('/') && !in_text_entry {
+            self.modal_state = ModalType::SearchEverywhere {
+                query: String::new(),
+                selected_idx: 0,
+                results: Vec::new(),
+            };
+            return Ok(());
+        }
+
         // Global sync shortcut — works on any screen except the editor (which uses Ctrl+S to save notes)
         if key.modifiers.contains(KeyModifiers::CONTROL)
             && key.code == KeyCode::Char('s')
@@ -2195,7 +2217,14 @@ impl App {
                 KeyCode::Char('p') => {
                     // Only pause audio if not on Fellowship screen (uses 'p' for companions tab)
                     if self.active_screen != ActiveScreen::Fellowship {
-                        self.audio_player.pause();
+                        use crate::audio::SOUNDSCAPES;
+                        if self.active_screen == ActiveScreen::Soundscapes
+                            && SOUNDSCAPES[self.selected_soundscape_idx].name == "Media Player"
+                        {
+                            crate::audio::mpris_player::play_pause();
+                        } else {
+                            self.audio_player.pause();
+                        }
                         return Ok(());
                     }
                 }
@@ -2212,13 +2241,20 @@ impl App {
                     }
                 }
                 KeyCode::Char('n') => {
-                    // Only cycle soundscape if not on Dashboard, Projects, Workspace, or Fellowship
+                    use crate::audio::SOUNDSCAPES;
+                    // MPRIS next track cuando el Media Player está seleccionado
+                    if self.active_screen == ActiveScreen::Soundscapes
+                        && SOUNDSCAPES[self.selected_soundscape_idx].name == "Media Player"
+                    {
+                        crate::audio::mpris_player::next_track();
+                        return Ok(());
+                    }
+                    // Otherwise cycle soundscape (not on screens that use 'n' for other things)
                     if self.active_screen != ActiveScreen::Dashboard
                         && self.active_screen != ActiveScreen::Projects
                         && self.active_screen != ActiveScreen::Workspace
                         && self.active_screen != ActiveScreen::Fellowship
                     {
-                        use crate::audio::SOUNDSCAPES;
                         let current = self.audio_player.get_state().current_soundscape;
                         let idx = SOUNDSCAPES
                             .iter()
@@ -2252,6 +2288,16 @@ impl App {
                         let sugs = App::path_suggestions(&current_val);
                         self.modal_state = ModalType::LocalMusicFolder { input: current_val, suggestions: sugs, selected: 0 };
                         return Ok(());
+                    }
+                }
+                KeyCode::Char('b') => {
+                    // pista anterior en MPRIS
+                    if self.active_screen == ActiveScreen::Soundscapes && self.modal_state == ModalType::None {
+                        use crate::audio::SOUNDSCAPES;
+                        if SOUNDSCAPES[self.selected_soundscape_idx].name == "Media Player" {
+                            crate::audio::mpris_player::prev_track();
+                            return Ok(());
+                        }
                     }
                 }
                 _ => {}
@@ -4828,7 +4874,7 @@ impl App {
                 self.active_screen = ActiveScreen::Character;
                 self.active_tab_idx = 2;
             }
-            KeyCode::Char('F') if self.active_screen == ActiveScreen::Projects => {
+            KeyCode::Char('f') | KeyCode::Char('F') if self.active_screen == ActiveScreen::Projects => {
                 self.active_screen = ActiveScreen::Focus;
                 self.active_tab_idx = 6;
             }
@@ -5410,6 +5456,10 @@ impl App {
                 } else if self.active_screen == ActiveScreen::Soundscapes {
                     use crate::audio::SOUNDSCAPES;
                     let s_name = SOUNDSCAPES[self.selected_soundscape_idx].name;
+                    if s_name == "Media Player" {
+                        crate::audio::mpris_player::play_pause();
+                        return Ok(());
+                    }
                     if s_name == "Local Folder" {
                         let folder = self.db.get_setting("local_music_folder").unwrap_or_default().unwrap_or_default();
                         if folder.trim().is_empty() {
@@ -8491,147 +8541,166 @@ impl App {
             return Vec::new();
         }
         let q = query.to_lowercase();
-        let mut results = Vec::new();
+        let mut scored: Vec<(u8, SearchResult)> = Vec::new();
 
-        // 1. Search Projects
-        if let Ok(projects) = self.db.get_projects() {
-            for p in projects {
-                if p.name.to_lowercase().contains(&q)
-                    || p.description
-                        .as_ref()
-                        .map(|d| d.to_lowercase().contains(&q))
-                        .unwrap_or(false)
-                {
-                    results.push(SearchResult {
-                        result_type: SearchResultType::Project,
-                        title: p.name.clone(),
-                        details: p
-                            .description
-                            .clone()
-                            .unwrap_or_else(|| "No description".to_string()),
-                        project_id: Some(p.id),
-                        item_id: p.id.to_string(),
-                    });
-                }
+        // Puntaje por relevancia: coincidencia exacta > empieza con > contiene en título > contiene en cuerpo
+        let score_match = |title: &str, content: Option<&str>| -> Option<u8> {
+            let t = title.to_lowercase();
+            if t == q { return Some(100); }
+            if t.starts_with(&q) { return Some(80); }
+            if t.contains(&q) { return Some(60); }
+            if content.map(|c| c.to_lowercase().contains(&q)).unwrap_or(false) { return Some(30); }
+            None
+        };
+
+        let projects = self.db.get_projects().unwrap_or_default();
+        let project_name: std::collections::HashMap<uuid::Uuid, &str> = projects.iter()
+            .map(|p| (p.id, p.name.as_str()))
+            .collect();
+
+        // 1. Proyectos
+        for p in &projects {
+            if let Some(s) = score_match(&p.name, p.description.as_deref()) {
+                scored.push((s, SearchResult {
+                    result_type: SearchResultType::Project,
+                    title: p.name.clone(),
+                    details: p.description.clone().unwrap_or_else(|| "No description".to_string()),
+                    project_id: Some(p.id),
+                    item_id: p.id.to_string(),
+                }));
             }
         }
 
-        // 2. Search Tasks
+        // 2. Tareas y Steps (pasos)
         if let Ok(tasks) = self.db.get_tasks() {
-            for t in tasks {
-                if t.title.to_lowercase().contains(&q)
-                    || t.description
-                        .as_ref()
-                        .map(|d| d.to_lowercase().contains(&q))
-                        .unwrap_or(false)
-                {
-                    results.push(SearchResult {
-                        result_type: SearchResultType::Task,
-                        title: t.title.clone(),
-                        details: format!("Task (Priority: {})", t.priority.name()),
-                        project_id: t.project_id,
-                        item_id: t.id.to_string(),
-                    });
-                }
-            }
-        }
-
-        // 3. Search Notes
-        if let Ok(projects) = self.db.get_projects() {
-            for p in &projects {
-                if let Ok(notes) = self.db.get_notes_for_project(p.id) {
-                    for n in notes {
-                        if n.title.to_lowercase().contains(&q)
-                            || n.markdown_content.to_lowercase().contains(&q)
-                        {
-                            results.push(SearchResult {
-                                result_type: SearchResultType::Note,
-                                title: n.title.clone(),
-                                details: format!("Note in project '{}'", p.name),
-                                project_id: Some(p.id),
-                                item_id: n.id.to_string(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-
-        // 4. Search Journal Entries
-        if let Ok(projects) = self.db.get_projects() {
-            for p in &projects {
-                if let Ok(journal) = self.db.get_journal_entries_for_project(p.id) {
-                    for j in journal {
-                        if j.content.to_lowercase().contains(&q) {
-                            results.push(SearchResult {
-                                result_type: SearchResultType::JournalEntry,
-                                title: format!("Journal - {}", j.entry_date),
-                                details: j.content.chars().take(60).collect(),
-                                project_id: Some(p.id),
-                                item_id: j.id.to_string(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-
-        // 5. Search Achievements
-        if let Ok(achievements) = self.db.get_achievements() {
-            for a in achievements {
-                if a.name.to_lowercase().contains(&q) || a.description.to_lowercase().contains(&q) {
-                    let status = if a.unlocked_at.is_some() {
-                        "Unlocked"
+            for t in &tasks {
+                if let Some(s) = score_match(&t.title, t.description.as_deref()) {
+                    let proj = t.project_id.and_then(|id| project_name.get(&id)).copied().unwrap_or("—");
+                    if t.parent_task_id.is_none() {
+                        scored.push((s, SearchResult {
+                            result_type: SearchResultType::Task,
+                            title: t.title.clone(),
+                            details: format!("{} · {} priority", proj, t.priority.name()),
+                            project_id: t.project_id,
+                            item_id: t.id.to_string(),
+                        }));
                     } else {
-                        "Locked"
-                    };
-                    results.push(SearchResult {
+                        scored.push((s, SearchResult {
+                            result_type: SearchResultType::Step,
+                            title: t.title.clone(),
+                            details: format!("{} · subtask", proj),
+                            project_id: t.project_id,
+                            item_id: t.id.to_string(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        // 3. Notas / Scrolls
+        for p in &projects {
+            if let Ok(notes) = self.db.get_notes_for_project(p.id) {
+                for n in &notes {
+                    if let Some(s) = score_match(&n.title, Some(&n.markdown_content)) {
+                        let snippet: String = n.markdown_content
+                            .chars().take(50).collect::<String>().replace('\n', " ");
+                        scored.push((s, SearchResult {
+                            result_type: SearchResultType::Note,
+                            title: n.title.clone(),
+                            details: format!("{} · {}", p.name, snippet),
+                            project_id: Some(p.id),
+                            item_id: n.id.to_string(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        // 4. Entradas del diario
+        for p in &projects {
+            if let Ok(journals) = self.db.get_journal_entries_for_project(p.id) {
+                for j in &journals {
+                    if j.content.to_lowercase().contains(&q) {
+                        let snippet: String = j.content.chars().take(50).collect();
+                        scored.push((30, SearchResult {
+                            result_type: SearchResultType::JournalEntry,
+                            title: format!("Journal - {}", j.entry_date),
+                            details: format!("{} · {}", p.name, snippet),
+                            project_id: Some(p.id),
+                            item_id: j.id.to_string(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        // 5. Milestones / Hitos
+        for p in &projects {
+            if let Ok(milestones) = self.db.get_milestones_for_project(p.id) {
+                for m in &milestones {
+                    if let Some(s) = score_match(&m.name, m.description.as_deref()) {
+                        let status = if m.completed { "Completed" } else { "In Progress" };
+                        scored.push((s, SearchResult {
+                            result_type: SearchResultType::Milestone,
+                            title: m.name.clone(),
+                            details: format!("{} · {}", p.name, status),
+                            project_id: Some(p.id),
+                            item_id: m.id.to_string(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        // 6. Logros / Achievements
+        if let Ok(achievements) = self.db.get_achievements() {
+            for a in &achievements {
+                if let Some(s) = score_match(&a.name, Some(&a.description)) {
+                    let status = if a.unlocked_at.is_some() { "Unlocked" } else { "Locked" };
+                    scored.push((s, SearchResult {
                         result_type: SearchResultType::Achievement,
                         title: format!("Achievement: {}", a.name),
                         details: format!("{} ({})", a.description, status),
                         project_id: None,
                         item_id: a.id.clone(),
-                    });
+                    }));
                 }
             }
         }
 
-        // 6. Search Lore
+        // 7. Lore / Biblioteca
         if let Ok(lore) = self.db.get_lore_entries() {
-            for l in lore {
-                if l.2.to_lowercase().contains(&q) || l.3.to_lowercase().contains(&q) {
-                    results.push(SearchResult {
+            for l in &lore {
+                if let Some(s) = score_match(&l.2, Some(&l.3)) {
+                    scored.push((s, SearchResult {
                         result_type: SearchResultType::Lore,
                         title: format!("Lore: {}", l.2),
-                        details: format!(
-                            "Category: {} - {}",
-                            l.1,
-                            if l.4 { "Unlocked" } else { "Locked" }
-                        ),
+                        details: format!("Category: {} - {}", l.1, if l.4 { "Unlocked" } else { "Locked" }),
                         project_id: None,
                         item_id: l.0.clone(),
-                    });
+                    }));
                 }
             }
         }
 
-        // 7. Search Chronicle Entries
+        // 8. Crónica
         if let Ok(entries) = self.db.get_chronicle_entries() {
-            for e in entries {
+            for e in &entries {
                 if e.2.to_lowercase().contains(&q) {
-                    results.push(SearchResult {
+                    scored.push((30, SearchResult {
                         result_type: SearchResultType::ChronicleEntry,
                         title: format!("Chronicle Day {}", e.1),
                         details: e.2.clone(),
                         project_id: None,
                         item_id: e.0.clone(),
-                    });
+                    }));
                 }
             }
         }
 
-        results.truncate(15);
-        results
+        // Ordena por puntaje y limita a 40 resultados
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.into_iter().map(|(_, r)| r).take(40).collect()
     }
 
     pub fn navigate_to_search_result(&mut self, result: &SearchResult) -> Result<()> {
@@ -8649,11 +8718,90 @@ impl App {
                     self.active_project_id = Some(p_id);
                     self.active_screen = ActiveScreen::Workspace;
                     self.workspace_tab_idx = 0;
-                    let tasks = self.db.get_tasks_for_project(p_id).unwrap_or_default();
+                    // Resetea filtro y modo drill-down para que la tarea sea visible
+                    self.task_filter = "All".to_string();
+                    self.viewing_step_for_task = None;
                     if let Ok(task_uuid) = uuid::Uuid::parse_str(&result.item_id) {
-                        if let Some(pos) = tasks.iter().position(|t| t.id == task_uuid) {
+                        self.reload_data()?;
+                        // Construye la lista plana idéntica al renderer para encontrar la posición correcta
+                        let tasks = self.db.get_tasks_for_project(p_id).unwrap_or_default();
+                        let mut parents: Vec<&crate::models::Task> = tasks.iter()
+                            .filter(|t| t.parent_task_id.is_none())
+                            .collect();
+                        match self.task_sort.as_str() {
+                            "DueDate" => parents.sort_by(|a, b| {
+                                a.completed.cmp(&b.completed).then_with(|| match (a.due_date, b.due_date) {
+                                    (Some(d1), Some(d2)) => d1.cmp(&d2),
+                                    (Some(_), None) => std::cmp::Ordering::Less,
+                                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                                    (None, None) => a.created_at.cmp(&b.created_at),
+                                })
+                            }),
+                            "Priority" => parents.sort_by(|a, b| {
+                                a.completed.cmp(&b.completed).then_with(|| b.priority.cmp(&a.priority))
+                            }),
+                            "Alphabetical" => parents.sort_by(|a, b| {
+                                a.completed.cmp(&b.completed)
+                                    .then_with(|| a.title.to_lowercase().cmp(&b.title.to_lowercase()))
+                            }),
+                            _ => parents.sort_by(|a, b| {
+                                a.completed.cmp(&b.completed).then_with(|| b.created_at.cmp(&a.created_at))
+                            }),
+                        }
+                        let mut flat_ids: Vec<uuid::Uuid> = Vec::new();
+                        for parent in &parents {
+                            flat_ids.push(parent.id);
+                            if !parent.completed {
+                                let mut steps: Vec<&crate::models::Task> = tasks.iter()
+                                    .filter(|t| t.parent_task_id == Some(parent.id) && !t.completed)
+                                    .collect();
+                                steps.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+                                for step in steps {
+                                    flat_ids.push(step.id);
+                                }
+                            }
+                        }
+                        if let Some(pos) = flat_ids.iter().position(|&id| id == task_uuid) {
                             self.selected_task_idx = pos;
                         }
+                        return Ok(());
+                    }
+                }
+            }
+            SearchResultType::Step => {
+                // Navega al task padre — los steps aparecen inline en la lista de tareas
+                if let Some(p_id) = result.project_id {
+                    self.active_project_id = Some(p_id);
+                    self.active_screen = ActiveScreen::Workspace;
+                    self.workspace_tab_idx = 0;
+                    self.task_filter = "All".to_string();
+                    self.viewing_step_for_task = None;
+                    if let Ok(step_uuid) = uuid::Uuid::parse_str(&result.item_id) {
+                        self.reload_data()?;
+                        let tasks = self.db.get_tasks_for_project(p_id).unwrap_or_default();
+                        let mut parents: Vec<&crate::models::Task> = tasks.iter()
+                            .filter(|t| t.parent_task_id.is_none())
+                            .collect();
+                        parents.sort_by(|a, b| {
+                            a.completed.cmp(&b.completed).then_with(|| b.created_at.cmp(&a.created_at))
+                        });
+                        let mut flat_ids: Vec<uuid::Uuid> = Vec::new();
+                        for parent in &parents {
+                            flat_ids.push(parent.id);
+                            if !parent.completed {
+                                let mut steps: Vec<&crate::models::Task> = tasks.iter()
+                                    .filter(|t| t.parent_task_id == Some(parent.id) && !t.completed)
+                                    .collect();
+                                steps.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+                                for step in steps {
+                                    flat_ids.push(step.id);
+                                }
+                            }
+                        }
+                        if let Some(pos) = flat_ids.iter().position(|&id| id == step_uuid) {
+                            self.selected_task_idx = pos;
+                        }
+                        return Ok(());
                     }
                 }
             }
@@ -8662,11 +8810,36 @@ impl App {
                     self.active_project_id = Some(p_id);
                     self.active_screen = ActiveScreen::Workspace;
                     self.workspace_tab_idx = 1;
-                    let notes = self.db.get_notes_for_project(p_id).unwrap_or_default();
                     if let Ok(note_uuid) = uuid::Uuid::parse_str(&result.item_id) {
-                        if let Some(pos) = notes.iter().position(|n| n.id == note_uuid) {
-                            self.selected_note_idx = pos;
+                        self.reload_data()?;
+                        let notes = self.db.get_notes_for_project(p_id).unwrap_or_default();
+                        let codices = self.db.get_codices_for_project(p_id).unwrap_or_default();
+                        // Construye la misma lista plana que draw_notes_tab: headers de codex + notas
+                        let mut flat: Vec<Option<uuid::Uuid>> = Vec::new();
+                        for codex in &codices {
+                            flat.push(None); // header de codex
+                            let mut codex_notes: Vec<&crate::models::Note> = notes.iter()
+                                .filter(|n| n.codex_id == Some(codex.id))
+                                .collect();
+                            codex_notes.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+                            for note in codex_notes {
+                                flat.push(Some(note.id));
+                            }
                         }
+                        let mut ungrouped: Vec<&crate::models::Note> = notes.iter()
+                            .filter(|n| n.codex_id.is_none() || !codices.iter().any(|c| Some(c.id) == n.codex_id))
+                            .collect();
+                        ungrouped.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+                        if !codices.is_empty() && !ungrouped.is_empty() {
+                            flat.push(None); // divisor
+                        }
+                        for note in &ungrouped {
+                            flat.push(Some(note.id));
+                        }
+                        if let Some(pos) = flat.iter().position(|id| *id == Some(note_uuid)) {
+                            self.selected_notes_flat_idx = pos;
+                        }
+                        return Ok(());
                     }
                 }
             }
@@ -8675,13 +8848,24 @@ impl App {
                     self.active_project_id = Some(p_id);
                     self.active_screen = ActiveScreen::Workspace;
                     self.workspace_tab_idx = 2;
-                    let journal = self
-                        .db
-                        .get_journal_entries_for_project(p_id)
-                        .unwrap_or_default();
+                    let journal = self.db.get_journal_entries_for_project(p_id).unwrap_or_default();
                     if let Ok(journal_uuid) = uuid::Uuid::parse_str(&result.item_id) {
                         if let Some(pos) = journal.iter().position(|j| j.id == journal_uuid) {
                             self.selected_journal_idx = pos;
+                        }
+                    }
+                }
+            }
+            SearchResultType::Milestone => {
+                if let Some(p_id) = result.project_id {
+                    self.active_project_id = Some(p_id);
+                    self.active_screen = ActiveScreen::Workspace;
+                    self.workspace_tab_idx = 3;
+                    if let Ok(milestones) = self.db.get_milestones_for_project(p_id) {
+                        if let Ok(m_uuid) = uuid::Uuid::parse_str(&result.item_id) {
+                            if let Some(pos) = milestones.iter().position(|m| m.id == m_uuid) {
+                                self.selected_milestone_idx = pos;
+                            }
                         }
                     }
                 }
@@ -8905,6 +9089,12 @@ fn fuzzy_match(query: &str, target: &str) -> Option<i32> {
                 shortcut: "M / 5",
                 id: "open_music",
             },
+            CommandAction {
+                name: "Cycle Ambient Effect",
+                description: "Switch the ambient particle effect on the Dashboard",
+                shortcut: "e (Dashboard)",
+                id: "cycle_ambient",
+            },
         ];
 
         if filter.is_empty() {
@@ -9049,6 +9239,28 @@ fn fuzzy_match(query: &str, target: &str) -> Option<i32> {
             "open_music" => {
                 self.active_screen = ActiveScreen::Soundscapes;
                 self.active_tab_idx = 7;
+            }
+            "cycle_ambient" => {
+                self.active_screen = ActiveScreen::Dashboard;
+                self.active_tab_idx = 0;
+                self.active_ambient_effect = (self.active_ambient_effect + 1) % 6;
+                self.db.set_setting(
+                    "active_ambient_effect",
+                    &self.active_ambient_effect.to_string(),
+                )?;
+                self.trigger_ambient_particles();
+                self.notifications.push(Notification::info(format!(
+                    "Ambient Effect: {}",
+                    match self.active_ambient_effect {
+                        0 => "Off",
+                        1 => "Falling Leaves",
+                        2 => "Stars",
+                        3 => "Rain",
+                        4 => "Snow",
+                        5 => "Glowing Runes",
+                        _ => "Off",
+                    }
+                )));
             }
             _ => {}
         }
@@ -9451,6 +9663,19 @@ fn fuzzy_match(query: &str, target: &str) -> Option<i32> {
             }
         }
         Ok(())
+    }
+
+    // poll de now-playing vía MPRIS cada 3 segundos cuando Media Player está seleccionado
+    pub fn tick_mpris(&mut self) {
+        use crate::audio::SOUNDSCAPES;
+        let is_selected = self.active_screen == ActiveScreen::Soundscapes
+            && self.selected_soundscape_idx < SOUNDSCAPES.len()
+            && SOUNDSCAPES[self.selected_soundscape_idx].name == "Media Player";
+
+        if is_selected && self.mpris_last_poll.elapsed().as_secs() >= 3 {
+            self.mpris_last_poll = std::time::Instant::now();
+            self.mpris_now_playing = crate::audio::mpris_player::get_now_playing();
+        }
     }
 
     pub fn tick_chat_poll(&mut self) -> Result<()> {

--- a/src/audio/capture.rs
+++ b/src/audio/capture.rs
@@ -1,0 +1,93 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// audio/capture.rs — captura el audio del sistema vía monitor de PulseAudio/PipeWire
+// permite mostrar el espectro de reproductores externos (MPRIS, Spotify, VLC, etc.)
+// usa pacat que viene incluido con pipewire-pulse o pulseaudio en Linux
+// ─────────────────────────────────────────────────────────────────────────────
+
+use crate::audio::spectrum::{update_from_mono, SpectrumData, FFT_SIZE, HOP_SIZE};
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::io::Read;
+
+const CAPTURE_RATE: u32 = 44100;
+// chunk pequeño para latencia baja — cada lectura de pacat tarda ~12ms
+const CAPTURE_CHUNK: usize = 512;
+
+// inicia la captura del monitor de audio del sistema en un hilo de fondo
+// escribe al mismo SpectrumData que usa SpectrumSource — se complementan sin conflictos
+pub fn start_system_capture(spectrum: SpectrumData) {
+    std::thread::spawn(move || {
+        // pacat es parte de pipewire-pulse o pulseaudio — en Arch Linux siempre presente
+        let mut child = match std::process::Command::new("pacat")
+            .args([
+                "--record",
+                "--device=@DEFAULT_MONITOR@",
+                "--format=float32le",
+                "--rate=44100",
+                "--channels=1",
+                "--latency-msec=30",
+            ])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(_) => {
+                crate::services::log_structured(
+                    "INFO",
+                    "capture",
+                    "pacat no disponible, captura del sistema desactivada",
+                    None,
+                );
+                return;
+            }
+        };
+
+        let mut stdout = match child.stdout.take() {
+            Some(s) => s,
+            None => return,
+        };
+
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(FFT_SIZE);
+        let scratch_len = fft.get_inplace_scratch_len();
+        let mut fft_buf = vec![Complex { re: 0.0f32, im: 0.0f32 }; FFT_SIZE];
+        let mut fft_scratch = vec![Complex { re: 0.0f32, im: 0.0f32 }; scratch_len];
+
+        let mut acc_buf: Vec<f32> = Vec::with_capacity(FFT_SIZE + HOP_SIZE);
+        let mut raw = vec![0u8; CAPTURE_CHUNK * 4]; // 4 bytes por muestra f32
+
+        loop {
+            if stdout.read_exact(&mut raw).is_err() {
+                break; // pacat terminó o el sistema de audio se desconectó
+            }
+
+            // convierte bytes F32LE a f32 — pacat ya entrega el formato correcto
+            for chunk in raw.chunks_exact(4) {
+                let bytes: [u8; 4] = chunk.try_into().unwrap();
+                acc_buf.push(f32::from_le_bytes(bytes));
+            }
+
+            // procesa en ventanas de FFT_SIZE con salto de HOP_SIZE (75% overlap)
+            while acc_buf.len() >= FFT_SIZE {
+                update_from_mono(
+                    &acc_buf,
+                    &fft,
+                    &mut fft_buf,
+                    &mut fft_scratch,
+                    &spectrum,
+                    CAPTURE_RATE,
+                );
+                acc_buf.drain(..HOP_SIZE);
+            }
+        }
+
+        // cuando pacat muere, desvanece el espectro suavemente en vez de congelarlo
+        if let Ok(mut spec) = spectrum.try_lock() {
+            for v in spec.iter_mut() {
+                *v *= 0.0;
+            }
+        }
+
+        let _ = child.kill();
+    });
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,9 +1,12 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // audio/mod.rs — re-exports del módulo de audio
 // ─────────────────────────────────────────────────────────────────────────────
+pub mod capture;
 pub mod generator;
 pub mod player;
 pub mod soundscapes;
+pub mod mpris_player;
+pub mod spectrum;
 pub mod state;
 pub mod streams;
 

--- a/src/audio/mpris_player.rs
+++ b/src/audio/mpris_player.rs
@@ -1,0 +1,56 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// audio/mpris_player.rs — controla reproductores de música vía MPRIS (D-Bus)
+// funciona con Spotify, VLC, Rhythmbox, y cualquier player compatible con MPRIS
+// sin OAuth, sin cuenta, sin configuración — solo abre tu reproductor favorito
+// ─────────────────────────────────────────────────────────────────────────────
+
+use mpris::PlayerFinder;
+
+#[derive(Debug, Clone)]
+pub struct NowPlaying {
+    pub title: String,
+    pub artist: String,
+    pub player: String,
+    pub is_playing: bool,
+}
+
+pub fn get_now_playing() -> Option<NowPlaying> {
+    let finder = PlayerFinder::new().ok()?;
+    let player = finder.find_active().ok()?;
+    let player_name = player.bus_name_trimmed().to_string();
+    let metadata = player.get_metadata().ok()?;
+    let status = player.get_playback_status().ok()?;
+
+    let title = metadata.title().unwrap_or("Unknown Track").to_string();
+    let artist = metadata
+        .artists()
+        .and_then(|a| a.first().map(|s| s.to_string()))
+        .unwrap_or_else(|| "Unknown Artist".to_string());
+    let is_playing = status == mpris::PlaybackStatus::Playing;
+
+    Some(NowPlaying { title, artist, player: player_name, is_playing })
+}
+
+pub fn play_pause() {
+    if let Ok(finder) = PlayerFinder::new() {
+        if let Ok(player) = finder.find_active() {
+            let _ = player.play_pause();
+        }
+    }
+}
+
+pub fn next_track() {
+    if let Ok(finder) = PlayerFinder::new() {
+        if let Ok(player) = finder.find_active() {
+            let _ = player.next();
+        }
+    }
+}
+
+pub fn prev_track() {
+    if let Ok(finder) = PlayerFinder::new() {
+        if let Ok(player) = finder.find_active() {
+            let _ = player.previous();
+        }
+    }
+}

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -4,7 +4,7 @@
 
 use crate::audio::state::{AudioState, PlaybackStatus};
 use crate::audio::streams::build_source;
-use rodio::{OutputStream, Sink};
+use rodio::{OutputStream, Sink, Source};
 use std::sync::{Arc, Mutex};
 #[cfg(not(target_os = "windows"))]
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
@@ -15,6 +15,7 @@ pub struct AudioPlayer {
     sink: Arc<Mutex<Option<Sink>>>,
     state: Arc<Mutex<AudioState>>,
     cinematic_sink: Arc<Mutex<Option<Sink>>>,
+    spectrum: crate::audio::spectrum::SpectrumData,
 }
 
 impl Default for AudioPlayer {
@@ -68,9 +69,12 @@ impl AudioPlayer {
             sink: Arc::new(Mutex::new(sink)),
             state,
             cinematic_sink: Arc::new(Mutex::new(None)),
+            spectrum: crate::audio::spectrum::new_spectrum_data(),
         };
         #[cfg(not(target_os = "windows"))]
         player.init_mpris();
+        // captura el monitor del sistema para mostrar espectro de reproductores externos (MPRIS)
+        crate::audio::capture::start_system_capture(player.spectrum.clone());
         player
     }
 
@@ -158,7 +162,11 @@ impl AudioPlayer {
     }
 
     pub fn play(&self, soundscape_name: &str) {
-        trigger_playback(soundscape_name, &self.state, &self.sink, &self.handle);
+        trigger_playback(soundscape_name, &self.state, &self.sink, &self.handle, &self.spectrum);
+    }
+
+    pub fn get_spectrum(&self) -> [f32; crate::audio::spectrum::NUM_BARS] {
+        *self.spectrum.lock().unwrap()
     }
 
     pub fn init_soundscape(&self, soundscape_name: &str) {
@@ -191,6 +199,10 @@ impl AudioPlayer {
         if let Some(ref sk) = *sink_guard {
             sk.stop();
         }
+        // limpia el espectro — ya no hay audio fluyendo por el sink
+        let _ = self.spectrum.try_lock().map(|mut s| {
+            *s = [0.0f32; crate::audio::spectrum::NUM_BARS];
+        });
     }
 
     // actualiza volumen en tiempo real sin reiniciar el stream — clampea entre 0 y 1
@@ -229,6 +241,7 @@ impl AudioPlayer {
         let state_clone = self.state.clone();
         let sink_clone = self.sink.clone();
         let handle_clone = self.handle.clone();
+        let spectrum_clone = self.spectrum.clone();
 
         // corre en su propio thread — el loop de MPRIS no debe bloquear el UI
         std::thread::spawn(move || {
@@ -317,17 +330,17 @@ impl AudioPlayer {
                         MediaControlEvent::Next => {
                             let current = state_clone.lock().unwrap().current_soundscape.clone();
                             if current == "Local Folder" || current.starts_with("Local:") {
-                                trigger_local_folder(state_clone.clone(), sink_clone.clone(), handle_clone.clone());
+                                trigger_local_folder(state_clone.clone(), sink_clone.clone(), handle_clone.clone(), spectrum_clone.clone());
                             } else if current == "Music For Programming" || current.starts_with("MFP:") {
-                                trigger_music_for_programming(state_clone.clone(), sink_clone.clone(), handle_clone.clone());
+                                trigger_music_for_programming(state_clone.clone(), sink_clone.clone(), handle_clone.clone(), spectrum_clone.clone());
                             }
                         }
                         MediaControlEvent::Previous => {
                             let current = state_clone.lock().unwrap().current_soundscape.clone();
                             if current == "Local Folder" || current.starts_with("Local:") {
-                                trigger_local_folder(state_clone.clone(), sink_clone.clone(), handle_clone.clone());
+                                trigger_local_folder(state_clone.clone(), sink_clone.clone(), handle_clone.clone(), spectrum_clone.clone());
                             } else if current == "Music For Programming" || current.starts_with("MFP:") {
-                                trigger_music_for_programming(state_clone.clone(), sink_clone.clone(), handle_clone.clone());
+                                trigger_music_for_programming(state_clone.clone(), sink_clone.clone(), handle_clone.clone(), spectrum_clone.clone());
                             }
                         }
                         _ => {}
@@ -374,6 +387,7 @@ fn trigger_playback(
     state_clone: &Arc<Mutex<AudioState>>,
     sink_clone: &Arc<Mutex<Option<Sink>>>,
     handle_clone: &Option<rodio::OutputStreamHandle>,
+    spectrum: &crate::audio::spectrum::SpectrumData,
 ) {
     let mut state = state_clone.lock().unwrap();
     state.current_soundscape = soundscape_name.to_string();
@@ -399,20 +413,21 @@ fn trigger_playback(
         // drop explícito antes de spawn para no tener deadlock en el otro thread
         drop(sink_guard);
         drop(state);
-        trigger_music_for_programming(state_clone.clone(), sink_clone.clone(), handle_clone.clone());
+        trigger_music_for_programming(state_clone.clone(), sink_clone.clone(), handle_clone.clone(), spectrum.clone());
         return;
     }
 
     if soundscape_name == "Local Folder" {
         drop(sink_guard);
         drop(state);
-        trigger_local_folder(state_clone.clone(), sink_clone.clone(), handle_clone.clone());
+        trigger_local_folder(state_clone.clone(), sink_clone.clone(), handle_clone.clone(), spectrum.clone());
         return;
     }
 
     if let Some(src) = build_source(soundscape_name) {
         if let Some(ref sk) = *sink_guard {
-            sk.append(src);
+            // envuelve la fuente en SpectrumTap para capturar muestras en tiempo real
+            sk.append(crate::audio::spectrum::SpectrumSource::new(src, spectrum.clone()));
             sk.play();
         }
     }
@@ -423,6 +438,7 @@ fn trigger_music_for_programming(
     state_clone: Arc<Mutex<AudioState>>,
     sink_clone: Arc<Mutex<Option<Sink>>>,
     handle_clone: Option<rodio::OutputStreamHandle>,
+    spectrum: crate::audio::spectrum::SpectrumData,
 ) {
     std::thread::spawn(move || {
         // todo esto corre en background — el UI no espera, la descarga puede tardar
@@ -524,7 +540,11 @@ fn trigger_music_for_programming(
             let volume = state_clone.lock().unwrap().volume;
             sink.set_volume(volume);
             sink.pause();
-            sink.append(source);
+            // convierte i16→f32 para poder envolver con SpectrumSource
+            sink.append(crate::audio::spectrum::SpectrumSource::new(
+                Box::new(source.convert_samples::<f32>()),
+                spectrum,
+            ));
             sink.play();
 
             {
@@ -543,6 +563,7 @@ fn trigger_local_folder(
     state_clone: Arc<Mutex<AudioState>>,
     sink_clone: Arc<Mutex<Option<Sink>>>,
     handle_clone: Option<rodio::OutputStreamHandle>,
+    spectrum: crate::audio::spectrum::SpectrumData,
 ) {
     // lee el path desde el state — nunca tocamos la DB desde el thread de audio
     let folder_path = {
@@ -646,7 +667,11 @@ fn trigger_local_folder(
                         .to_string();
                 }
 
-                sink.append(source);
+                // convierte i16→f32 antes del SpectrumSource — cada archivo comparte el mismo Arc
+                sink.append(crate::audio::spectrum::SpectrumSource::new(
+                    Box::new(source.convert_samples::<f32>()),
+                    spectrum.clone(),
+                ));
                 play_count += 1;
             }
 

--- a/src/audio/soundscapes.rs
+++ b/src/audio/soundscapes.rs
@@ -8,7 +8,13 @@ pub struct SoundscapeInfo {
     pub bonus: &'static str,
 }
 
-pub const SOUNDSCAPES: [SoundscapeInfo; 8] = [
+pub const SOUNDSCAPES: [SoundscapeInfo; 9] = [
+    SoundscapeInfo {
+        name: "Media Player",
+        symbol: "",
+        description: "Control any MPRIS-compatible player: Spotify, VLC, Rhythmbox, and more.",
+        bonus: "+5% Focus XP — syncs with your listening mood",
+    },
     SoundscapeInfo {
         name: "Music For Programming",
         symbol: "",

--- a/src/audio/spectrum.rs
+++ b/src/audio/spectrum.rs
@@ -1,0 +1,169 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// audio/spectrum.rs — wrapper de fuente de audio que intercepta las muestras
+// y calcula un espectro de frecuencias en tiempo real usando FFT
+// ─────────────────────────────────────────────────────────────────────────────
+
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::sync::{Arc, Mutex};
+
+pub const NUM_BARS: usize = 48;
+pub const FFT_SIZE: usize = 1024;
+pub const HOP_SIZE: usize = 256;
+// decay rápido al subir (ataque instantáneo), lento al bajar (caída suave como VU meter)
+pub const DECAY: f32 = 0.92;
+
+pub type SpectrumData = Arc<Mutex<[f32; NUM_BARS]>>;
+
+pub fn new_spectrum_data() -> SpectrumData {
+    Arc::new(Mutex::new([0.0f32; NUM_BARS]))
+}
+
+// calcula el FFT sobre las primeras FFT_SIZE muestras del buffer mono y escribe el espectro
+// — reutilizado tanto por SpectrumSource (rodio) como por el hilo de captura del sistema
+pub fn update_from_mono(
+    buffer: &[f32],
+    fft: &Arc<dyn rustfft::Fft<f32>>,
+    fft_buf: &mut Vec<Complex<f32>>,
+    fft_scratch: &mut Vec<Complex<f32>>,
+    spectrum: &SpectrumData,
+    sample_rate: u32,
+) {
+    let sr = sample_rate as f32;
+
+    // ventana Hanning para reducir spectral leakage en los bordes del buffer
+    for (i, (&s, c)) in buffer[..FFT_SIZE].iter().zip(fft_buf.iter_mut()).enumerate() {
+        let w = 0.5
+            * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / (FFT_SIZE - 1) as f32).cos());
+        c.re = s * w;
+        c.im = 0.0;
+    }
+
+    fft.process_with_scratch(fft_buf, fft_scratch);
+
+    let bins = FFT_SIZE / 2;
+    // rango audible de 30 Hz a 16 kHz en escala logarítmica — igual que en un analizador real
+    let f_lo: f32 = 30.0;
+    let f_hi: f32 = 16_000.0;
+    let log_ratio = (f_hi / f_lo).ln();
+
+    let mut new_bands = [0.0f32; NUM_BARS];
+    for bar in 0..NUM_BARS {
+        let t_lo = bar as f32 / NUM_BARS as f32;
+        let t_hi = (bar + 1) as f32 / NUM_BARS as f32;
+        let freq_lo = f_lo * (log_ratio * t_lo).exp();
+        let freq_hi = f_lo * (log_ratio * t_hi).exp();
+
+        let bin_lo = ((freq_lo / sr * FFT_SIZE as f32) as usize).max(1).min(bins - 1);
+        let bin_hi = ((freq_hi / sr * FFT_SIZE as f32) as usize + 1)
+            .max(bin_lo + 1)
+            .min(bins);
+
+        let count = (bin_hi - bin_lo) as f32;
+        let sum_sq: f32 =
+            fft_buf[bin_lo..bin_hi].iter().map(|c| c.norm_sqr()).sum::<f32>() / count;
+
+        // escala dB perceptual: mapea -60 dB→0.0, 0 dB→1.0 para buena dinámica visual
+        let amplitude = 2.0 * sum_sq.sqrt() / FFT_SIZE as f32;
+        let db = 20.0 * amplitude.max(1e-10_f32).log10();
+        new_bands[bar] = ((db + 60.0) / 60.0).clamp(0.0, 1.0);
+    }
+
+    // try_lock para no bloquear el hilo que llama si el UI está leyendo al mismo tiempo
+    if let Ok(mut spec) = spectrum.try_lock() {
+        for i in 0..NUM_BARS {
+            if new_bands[i] > spec[i] {
+                spec[i] = new_bands[i];
+            } else {
+                spec[i] = (spec[i] * DECAY).max(new_bands[i]);
+            }
+        }
+    }
+}
+
+pub struct SpectrumSource {
+    inner: Box<dyn rodio::Source<Item = f32> + Send + 'static>,
+    buffer: Vec<f32>,
+    spectrum: SpectrumData,
+    fft: Arc<dyn rustfft::Fft<f32>>,
+    fft_buf: Vec<Complex<f32>>,
+    fft_scratch: Vec<Complex<f32>>,
+    sample_rate: u32,
+    channels: u16,
+    ch_acc: f32,
+    ch_idx: u16,
+}
+
+impl SpectrumSource {
+    pub fn new(
+        inner: Box<dyn rodio::Source<Item = f32> + Send + 'static>,
+        spectrum: SpectrumData,
+    ) -> Self {
+        let sample_rate = inner.sample_rate();
+        let channels = inner.channels().max(1);
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(FFT_SIZE);
+        let scratch_len = fft.get_inplace_scratch_len();
+        Self {
+            inner,
+            buffer: Vec::with_capacity(FFT_SIZE + HOP_SIZE),
+            spectrum,
+            fft,
+            fft_buf: vec![Complex { re: 0.0, im: 0.0 }; FFT_SIZE],
+            fft_scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len],
+            sample_rate,
+            channels,
+            ch_acc: 0.0,
+            ch_idx: 0,
+        }
+    }
+
+    fn compute_fft(&mut self) {
+        let buffer = &self.buffer;
+        let fft = &self.fft;
+        let fft_buf = &mut self.fft_buf;
+        let fft_scratch = &mut self.fft_scratch;
+        let spectrum = &self.spectrum;
+        let sample_rate = self.sample_rate;
+        update_from_mono(buffer, fft, fft_buf, fft_scratch, spectrum, sample_rate);
+    }
+}
+
+impl Iterator for SpectrumSource {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<f32> {
+        let sample = self.inner.next()?;
+
+        // acumula samples del frame actual para promediar a mono antes del FFT
+        self.ch_acc += sample;
+        self.ch_idx += 1;
+        if self.ch_idx >= self.channels {
+            self.buffer.push(self.ch_acc / self.channels as f32);
+            self.ch_acc = 0.0;
+            self.ch_idx = 0;
+
+            if self.buffer.len() >= FFT_SIZE {
+                self.compute_fft();
+                // ventana deslizante con 75% de overlap — más resolución temporal
+                self.buffer.drain(..HOP_SIZE);
+            }
+        }
+
+        Some(sample)
+    }
+}
+
+impl rodio::Source for SpectrumSource {
+    fn current_frame_len(&self) -> Option<usize> {
+        self.inner.current_frame_len()
+    }
+    fn channels(&self) -> u16 {
+        self.inner.channels()
+    }
+    fn sample_rate(&self) -> u32 {
+        self.inner.sample_rate()
+    }
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner.total_duration()
+    }
+}

--- a/src/audio/spotify.rs
+++ b/src/audio/spotify.rs
@@ -1,0 +1,439 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// audio/spotify.rs — cliente de Spotify Connect via Web API con PKCE OAuth
+// ─────────────────────────────────────────────────────────────────────────────
+
+use anyhow::{anyhow, Result};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SCOPES: &str =
+    "user-read-playback-state user-modify-playback-state user-read-currently-playing playlist-read-private playlist-read-collaborative";
+
+// construye el redirect URI a partir de la URL base del servidor
+pub fn redirect_uri(server_url: &str) -> String {
+    let base = server_url.trim_end_matches('/');
+    format!("{}/spotify/callback", base)
+}
+
+// jala el client_id del servidor — así los usuarios no tienen que configurar nada
+pub fn fetch_client_id(server_url: &str) -> Result<String> {
+    let url = format!("{}/spotify/config", server_url.trim_end_matches('/'));
+    let resp = ureq::get(&url)
+        .timeout(std::time::Duration::from_secs(8))
+        .call()
+        .map_err(|e| anyhow!("Could not reach Questline server: {}", e))?;
+    let json: serde_json::Value = resp.into_json()?;
+    json["client_id"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("Server returned no Spotify client_id"))
+}
+
+#[derive(Debug, Clone)]
+pub struct SpotifyPlaylist {
+    pub id: String,
+    pub name: String,
+    pub uri: String,
+    pub track_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpotifyNowPlaying {
+    pub track: String,
+    pub artist: String,
+    pub is_playing: bool,
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// genera verifier (43 bytes URL-safe) y challenge (SHA-256 base64url del verifier)
+pub fn generate_pkce() -> (String, String) {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    // semilla combinando pid + tiempo — no necesitamos crypto-rand para el verifier
+    let seed = {
+        let mut h = DefaultHasher::new();
+        std::process::id().hash(&mut h);
+        unix_now().hash(&mut h);
+        h.finish()
+    };
+
+    // verifier: 64 chars URL-safe a partir del seed
+    let chars: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut state = seed;
+    let verifier: String = (0..64)
+        .map(|_| {
+            // xorshift para no repetir el mismo carácter
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            chars[(state as usize) % chars.len()] as char
+        })
+        .collect();
+
+    // challenge: SHA-256 del verifier codificado en base64url
+    // Rust stdlib no trae SHA-256, así que implementamos el S256 usando una versión simple
+    let challenge = sha256_base64url(verifier.as_bytes());
+    (verifier, challenge)
+}
+
+// SHA-256 puro en Rust sin dependencias externas
+fn sha256_base64url(data: &[u8]) -> String {
+    let hash = sha256(data);
+    // base64url sin padding
+    let b64 = base64url_encode(&hash);
+    b64
+}
+
+fn base64url_encode(data: &[u8]) -> String {
+    const TABLE: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    let mut i = 0;
+    while i < data.len() {
+        let b0 = data[i] as u32;
+        let b1 = if i + 1 < data.len() { data[i + 1] as u32 } else { 0 };
+        let b2 = if i + 2 < data.len() { data[i + 2] as u32 } else { 0 };
+        out.push(TABLE[((b0 >> 2) & 0x3F) as usize] as char);
+        out.push(TABLE[(((b0 & 3) << 4) | (b1 >> 4)) as usize] as char);
+        if i + 1 < data.len() {
+            out.push(TABLE[(((b1 & 0xF) << 2) | (b2 >> 6)) as usize] as char);
+        }
+        if i + 2 < data.len() {
+            out.push(TABLE[(b2 & 0x3F) as usize] as char);
+        }
+        i += 3;
+    }
+    out
+}
+
+// SHA-256 estándar — constantes y lógica del RFC 4634
+fn sha256(data: &[u8]) -> [u8; 32] {
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ];
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ];
+
+    let bit_len = (data.len() as u64) * 8;
+    let mut padded = data.to_vec();
+    padded.push(0x80);
+    while padded.len() % 64 != 56 {
+        padded.push(0);
+    }
+    padded.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in padded.chunks(64) {
+        let mut w = [0u32; 64];
+        for (i, b) in chunk.chunks(4).enumerate().take(16) {
+            w[i] = u32::from_be_bytes([b[0], b[1], b[2], b[3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16].wrapping_add(s0).wrapping_add(w[i - 7]).wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] =
+            [h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]];
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let tmp1 = hh.wrapping_add(s1).wrapping_add(ch).wrapping_add(K[i]).wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let tmp2 = s0.wrapping_add(maj);
+            hh = g; g = f; f = e;
+            e = d.wrapping_add(tmp1);
+            d = c; c = b; b = a;
+            a = tmp1.wrapping_add(tmp2);
+        }
+        h[0] = h[0].wrapping_add(a); h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c); h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e); h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g); h[7] = h[7].wrapping_add(hh);
+    }
+
+    let mut out = [0u8; 32];
+    for (i, &word) in h.iter().enumerate() {
+        out[i * 4..(i + 1) * 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+pub fn build_auth_url(client_id: &str, challenge: &str, state: &str, redirect_uri: &str) -> String {
+    format!(
+        "https://accounts.spotify.com/authorize?client_id={}&response_type=code\
+         &redirect_uri={}&code_challenge_method=S256&code_challenge={}\
+         &scope={}&state={}",
+        url_encode(client_id),
+        url_encode(redirect_uri),
+        url_encode(challenge),
+        url_encode(SCOPES),
+        url_encode(state),
+    )
+}
+
+fn url_encode(s: &str) -> String {
+    let mut out = String::new();
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+    out
+}
+
+// intercambia el código de autorización por tokens de acceso y refresco
+pub fn exchange_code(
+    client_id: &str,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<(String, String, u64)> {
+    let body = format!(
+        "client_id={}&grant_type=authorization_code&code={}&redirect_uri={}&code_verifier={}",
+        url_encode(client_id),
+        url_encode(code),
+        url_encode(redirect_uri),
+        url_encode(verifier),
+    );
+
+    let resp = ureq::post("https://accounts.spotify.com/api/token")
+        .set("Content-Type", "application/x-www-form-urlencoded")
+        .timeout(std::time::Duration::from_secs(10))
+        .send_string(&body)
+        .map_err(|e| anyhow!("Token exchange failed: {}", e))?;
+
+    let json: serde_json::Value = resp.into_json()?;
+    let access_token = json["access_token"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No access_token in response"))?
+        .to_string();
+    let refresh_token = json["refresh_token"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No refresh_token in response"))?
+        .to_string();
+    let expires_in = json["expires_in"].as_u64().unwrap_or(3600);
+    let expiry = unix_now() + expires_in - 60;
+
+    Ok((access_token, refresh_token, expiry))
+}
+
+// renueva el access token usando el refresh token
+pub fn refresh_access_token(client_id: &str, refresh_tok: &str) -> Result<(String, u64)> {
+    let body = format!(
+        "client_id={}&grant_type=refresh_token&refresh_token={}",
+        url_encode(client_id),
+        url_encode(refresh_tok),
+    );
+
+    let resp = ureq::post("https://accounts.spotify.com/api/token")
+        .set("Content-Type", "application/x-www-form-urlencoded")
+        .timeout(std::time::Duration::from_secs(10))
+        .send_string(&body)
+        .map_err(|e| anyhow!("Token refresh failed: {}", e))?;
+
+    let json: serde_json::Value = resp.into_json()?;
+    let access_token = json["access_token"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No access_token in refresh response"))?
+        .to_string();
+    let expires_in = json["expires_in"].as_u64().unwrap_or(3600);
+    let expiry = unix_now() + expires_in - 60;
+
+    Ok((access_token, expiry))
+}
+
+// error especial para indicar token inválido — el caller debe limpiar los tokens y re-autenticar
+pub const ERR_UNAUTHORIZED: &str = "SPOTIFY_UNAUTHORIZED";
+
+pub fn get_playlists(access_token: &str) -> Result<Vec<SpotifyPlaylist>> {
+    let resp = match ureq::get("https://api.spotify.com/v1/me/playlists?limit=50")
+        .set("Authorization", &format!("Bearer {}", access_token))
+        .timeout(std::time::Duration::from_secs(10))
+        .call()
+    {
+        Ok(r) => r,
+        Err(ureq::Error::Status(401, _)) => return Err(anyhow!(ERR_UNAUTHORIZED)),
+        // 403 = el app de Spotify no tiene "Web API" habilitado en developer.spotify.com
+        Err(ureq::Error::Status(403, _)) => {
+            return Err(anyhow!("Spotify 403: enable 'Web API' in your Spotify Developer App settings"));
+        }
+        Err(e) => return Err(anyhow!("Network error fetching playlists: {}", e)),
+    };
+
+    let json: serde_json::Value = resp.into_json()?;
+    let items = json["items"].as_array().cloned().unwrap_or_default();
+
+    let playlists = items
+        .iter()
+        .filter_map(|item| {
+            let id = item["id"].as_str()?.to_string();
+            let name = item["name"].as_str().unwrap_or("Untitled").to_string();
+            let uri = item["uri"].as_str().unwrap_or("").to_string();
+            let track_count = item["tracks"]["total"].as_u64().unwrap_or(0) as u32;
+            Some(SpotifyPlaylist { id, name, uri, track_count })
+        })
+        .collect();
+
+    Ok(playlists)
+}
+
+pub fn start_playlist(access_token: &str, playlist_uri: &str) -> Result<()> {
+    let body = serde_json::json!({ "context_uri": playlist_uri });
+    let resp = ureq::put("https://api.spotify.com/v1/me/player/play")
+        .set("Authorization", &format!("Bearer {}", access_token))
+        .set("Content-Type", "application/json")
+        .timeout(std::time::Duration::from_secs(10))
+        .send_json(body);
+
+    match resp {
+        Ok(_) => Ok(()),
+        Err(ureq::Error::Status(404, _)) => Err(anyhow!(
+            "No active Spotify device found. Open Spotify on any device first."
+        )),
+        Err(ureq::Error::Status(403, _)) => Err(anyhow!(
+            "Playback requires Spotify Premium."
+        )),
+        Err(e) => Err(anyhow!("Playback failed: {}", e)),
+    }
+}
+
+pub fn get_now_playing(access_token: &str) -> Result<Option<SpotifyNowPlaying>> {
+    let resp = ureq::get("https://api.spotify.com/v1/me/player/currently-playing")
+        .set("Authorization", &format!("Bearer {}", access_token))
+        .timeout(std::time::Duration::from_secs(8))
+        .call();
+
+    match resp {
+        Ok(r) => {
+            if r.status() == 204 {
+                return Ok(None); // nada reproduciéndose
+            }
+            let json: serde_json::Value = r.into_json()?;
+            let is_playing = json["is_playing"].as_bool().unwrap_or(false);
+            let track = json["item"]["name"]
+                .as_str()
+                .unwrap_or("Unknown Track")
+                .to_string();
+            let artist = json["item"]["artists"][0]["name"]
+                .as_str()
+                .unwrap_or("Unknown Artist")
+                .to_string();
+            Ok(Some(SpotifyNowPlaying { track, artist, is_playing }))
+        }
+        Err(ureq::Error::Status(204, _)) => Ok(None),
+        // 401 = token expirado, hay que re-autenticar
+        Err(ureq::Error::Status(401, _)) => Err(anyhow!(ERR_UNAUTHORIZED)),
+        // 403 = sin Premium o sin dispositivo activo — no es error de token
+        Err(ureq::Error::Status(403, _)) => Ok(None),
+        Err(e) => Err(anyhow!("Failed to get now playing: {}", e)),
+    }
+}
+
+pub fn pause_playback(access_token: &str) -> Result<()> {
+    ureq::put("https://api.spotify.com/v1/me/player/pause")
+        .set("Authorization", &format!("Bearer {}", access_token))
+        .timeout(std::time::Duration::from_secs(8))
+        .call()
+        .map(|_| ())
+        .map_err(|e| anyhow!("Pause failed: {}", e))
+}
+
+pub fn resume_playback(access_token: &str) -> Result<()> {
+    ureq::put("https://api.spotify.com/v1/me/player/play")
+        .set("Authorization", &format!("Bearer {}", access_token))
+        .set("Content-Type", "application/json")
+        .timeout(std::time::Duration::from_secs(8))
+        .send_string("{}")
+        .map(|_| ())
+        .map_err(|e| anyhow!("Resume failed: {}", e))
+}
+
+pub fn skip_to_next(access_token: &str) -> Result<()> {
+    ureq::post("https://api.spotify.com/v1/me/player/next")
+        .set("Authorization", &format!("Bearer {}", access_token))
+        .timeout(std::time::Duration::from_secs(8))
+        .call()
+        .map(|_| ())
+        .map_err(|e| anyhow!("Skip failed: {}", e))
+}
+
+// consulta el servidor de Questline cada segundo hasta recibir el código OAuth
+// — el navegador ya entregó el código al callback del servidor, aquí solo lo retiramos
+pub fn start_code_poller(server_url: String, state: String) -> std::sync::mpsc::Receiver<String> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let poll_url = format!(
+            "{}/spotify/token?state={}",
+            server_url.trim_end_matches('/'),
+            state
+        );
+        // timeout de 5 minutos — si el user no autoriza en ese tiempo, se cancela
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
+
+        loop {
+            if std::time::Instant::now() >= deadline {
+                crate::services::log_structured(
+                    "WARNING",
+                    "spotify_poll",
+                    "Spotify auth timed out after 5 minutes",
+                    None,
+                );
+                break;
+            }
+
+            match ureq::get(&poll_url).timeout(std::time::Duration::from_secs(5)).call() {
+                Ok(resp) => {
+                    if let Ok(json) = resp.into_json::<serde_json::Value>() {
+                        if let Some(code) = json["code"].as_str() {
+                            let _ = tx.send(code.to_string());
+                            break;
+                        }
+                    }
+                }
+                Err(ureq::Error::Status(404, _)) => {
+                    // aún pendiente — el usuario no ha completado el login en el browser
+                }
+                Err(e) => {
+                    crate::services::log_structured(
+                        "ERROR",
+                        "spotify_poll",
+                        "Error polling Spotify token endpoint",
+                        Some(&e.to_string()),
+                    );
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+    });
+    rx
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,7 @@ async fn main() -> Result<()> {
         app.tick_chat_poll()?;
         app.tick_presence_update()?;
         app.tick_focus_session()?;
+        app.tick_mpris();
         app.tick_particles();
         app.tick_update_check();
         app.tick_chapter_progress();
@@ -389,16 +390,14 @@ async fn main() -> Result<()> {
                     }
 
                     // Render Footer Help Info
-                    let tabs_str = "[1]D [2]P [3]H [4]L [5]M [6]S [7]F [8]G ?";
-
                     let footer_block = Block::default()
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded)
                         .border_style(Style::default().fg(Color::DarkGray));
-                    
+
                     let footer_area = footer_block.inner(chunks[1]);
                     f.render_widget(footer_block, chunks[1]);
-                    
+
                     let footer_cols = Layout::default()
                         .direction(Direction::Horizontal)
                         .constraints([
@@ -408,19 +407,58 @@ async fn main() -> Result<()> {
                         ])
                         .split(footer_area);
 
-                    let footer_text = vec![
-                        Line::from(vec![
-                            Span::styled(" Keys: ", Style::default().fg(Color::Rgb(140, 140, 140))),
-                            Span::styled(tabs_str, Style::default().fg(theme.primary).add_modifier(Modifier::BOLD)),
-                            Span::styled(" | ", Style::default().fg(Color::Rgb(140, 140, 140))),
-                            Span::styled("Tab/Shift+Tab", Style::default().fg(theme.primary)),
-                            Span::styled(" cycle | ", Style::default().fg(Color::Rgb(140, 140, 140))),
-                            Span::styled("Ctrl+P", Style::default().fg(theme.primary).add_modifier(Modifier::BOLD)),
-                            Span::styled(" palette | ", Style::default().fg(Color::Rgb(140, 140, 140))),
-                            Span::styled("Q", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
-                            Span::styled(" quit", Style::default().fg(Color::Rgb(140, 140, 140))),
-                        ])
+                    // Tabs de navegación: activo muestra nombre completo con color de clase
+                    let nav_tabs: &[(&str, ActiveScreen)] = &[
+                        ("Dashboard",  ActiveScreen::Dashboard),
+                        ("Projects",   ActiveScreen::Projects),
+                        ("Hero",       ActiveScreen::Character),
+                        ("Library",    ActiveScreen::Library),
+                        ("Music",      ActiveScreen::Soundscapes),
+                        ("Sync",       ActiveScreen::SyncSettings),
+                        ("Fellowship", ActiveScreen::Fellowship),
+                        ("Chronicle",  ActiveScreen::GreatChronicle),
                     ];
+
+                    let muted = Color::Rgb(90, 90, 90);
+                    let mut tab_spans: Vec<Span> = vec![Span::styled(" ", Style::default())];
+                    for (i, (name, screen)) in nav_tabs.iter().enumerate() {
+                        let num = i + 1;
+                        if app.active_screen == *screen {
+                            tab_spans.push(Span::styled(
+                                format!("[{}]{}", num, name),
+                                Style::default()
+                                    .fg(Color::Black)
+                                    .bg(theme.primary)
+                                    .add_modifier(Modifier::BOLD),
+                            ));
+                        } else {
+                            tab_spans.push(Span::styled(
+                                format!("{}", num),
+                                Style::default().fg(muted),
+                            ));
+                        }
+                        tab_spans.push(Span::styled(" ", Style::default()));
+                    }
+                    // Tab de About — activa con [?]About
+                    if app.active_screen == ActiveScreen::About {
+                        tab_spans.push(Span::styled(
+                            "[?]About",
+                            Style::default()
+                                .fg(Color::Black)
+                                .bg(theme.primary)
+                                .add_modifier(Modifier::BOLD),
+                        ));
+                    } else {
+                        tab_spans.push(Span::styled("?", Style::default().fg(muted)));
+                    }
+                    tab_spans.push(Span::styled(" ", Style::default()));
+                    tab_spans.push(Span::styled("| ", Style::default().fg(muted)));
+                    tab_spans.push(Span::styled("Ctrl+P", Style::default().fg(theme.primary).add_modifier(Modifier::BOLD)));
+                    tab_spans.push(Span::styled(" palette  ", Style::default().fg(muted)));
+                    tab_spans.push(Span::styled("Q", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)));
+                    tab_spans.push(Span::styled(" quit", Style::default().fg(muted)));
+
+                    let footer_text = vec![Line::from(tab_spans)];
 
                     // Sync status: 10s transient para éxito/fallo — permanente si hay 3+ fallos consecutivos
                     let sync_line = if app.sync_failure_count >= 3 {

--- a/src/models/rpg.rs
+++ b/src/models/rpg.rs
@@ -20,24 +20,28 @@ impl ZenTree {
     pub fn stage_name(&self) -> &'static str {
         match self.stage {
             1 => "Acorn",
-            2 => "Sapling",
-            3 => "Treekin",
-            4 => "Grovekeeper",
-            5 => "Ancient Warden",
-            6 => "Forest Elder",
-            _ => "World Tree",
+            2 => "Sprout",
+            3 => "Young Entling",
+            4 => "Grove Guardian",
+            5 => "Ancient Ent",
+            6 => "Evergrowth Elder",
+            _ => "Evergrowth Tree",
         }
     }
 
     pub fn ascii_art(&self) -> &'static str {
-        match self.stage {
-            1 => "      .\n     ( )\n",
-            2 => "      ,\n     /|\n      |\n",
-            3 => "     \\|/\n      |\n      |\n",
-            4 => "     /*\\\n    /***\\\\\n      |\n      |\n",
-            5 => "     .ooo.\n   .oQOOPQo.\n    OOPQOQO\n     |  |\n     |  |\n",
-            6 => "      .ooo.\n    .oQOOPQo.\n   .oQOQOQOQo.\n     || ||\n     || ||\n",
-            _ => "      .ooo.\n    .oQOOPQo.\n   .oQOQOQOQo.\n  .oQOQOQOQOQo.\n    ||| |||\n    ||| |||\n",
+        Self::ascii_art_at_stage(self.stage)
+    }
+
+    pub fn ascii_art_at_stage(stage: i32) -> &'static str {
+        match stage {
+            1 => "    .\n   ( )\n",
+            2 => "    .\n   \\|/\n    |\n    '\n",
+            3 => "    ,\n   \\|/\n  --|--\n    |\n   / \\\n",
+            4 => "    .^.\n   /^^\\  \n  <^^^^>\n    ||\n    ||\n   /__\\\n",
+            5 => "     .-^^^-.\n   .^^^^^^^^^.\n  <^^^^^^^^^^^>\n <^^^^^^^^^^^^^>\n      ||||\n      ||||\n     /||||\\\n",
+            6 => "        .-^^^^^-.\n     .^^^^^^^^^^^^.\n   .^^^^^^^^^^^^^^^^.\n  <^^^^^^^^^^^^^^^^^^>\n <^^^^^^^^^^^^^^^^^^^^>\n<^^^^^^^^^^^^^^^^^^^^^^>\n        ||||||\n        ||||||\n      __||||||__\n",
+            _ => "          .-^^^^^^^^^-.\n      .^^^^^^^^^^^^^^^^^^.\n    .^^^^^^^^^^^^^^^^^^^^^^.\n  .^^^^^^^^^^^^^^^^^^^^^^^^^^.\n <^^^^^^^^^^^^^^^^^^^^^^^^^^^^>\n<^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^>\n <^^^^^^^^^^^^^^^^^^^^^^^^^^^^>\n   \\^^^^^^^^^^^^^^^^^^^^^^^^/\n        ||||||||||||\n        ||||||||||||\n     ___||||||||||||___\n",
         }
     }
 }

--- a/src/screens/about.rs
+++ b/src/screens/about.rs
@@ -205,6 +205,33 @@ fn changelog_lines(theme: &Theme, accent: Color) -> Vec<Line<'static>> {
     // Historial de versiones hardcodeado — pues hay que actualizar esto con cada release
     const VERSIONS: &[(&str, &str, &str, &[&str])] = &[
         (
+            "v1.0.8", "Jul 6, 2026",
+            "The Focus Session Listens Now",
+            &[
+                "Music visualizer now shows real audio",
+                "Works with Spotify, VLC, mpv, and any player",
+                "Local soundscapes also show real frequencies",
+                "Bars jump up instantly, fall off smoothly",
+                "Search now navigates to the exact note or task",
+                "Results ranked by relevance (title first)",
+                "Search also covers steps and milestones",
+                "Press / anywhere to open search instantly",
+                "Ambient effects accessible from Command Palette",
+            ],
+        ),
+        (
+            "v1.0.7", "Jul 1, 2026",
+            "Music, Motion, and a New Address",
+            &[
+                "Moved to questlinecli.com",
+                "Added MPRIS media player support",
+                "Control any player: Spotify, VLC, Rhythmbox",
+                "Music visualizer added to Focus tab",
+                "Companion tree grows during focus sessions",
+                "Realm Activity feed in Great Chronicle",
+            ],
+        ),
+        (
             "v1.0.6", "Jun 26, 2026",
             "The Notification Swarm",
             &[

--- a/src/screens/focus.rs
+++ b/src/screens/focus.rs
@@ -86,7 +86,8 @@ fn draw_active_session(f: &mut Frame, app: &App, theme: &Theme, size: Rect) {
         .constraints([
             Constraint::Length(3), // Header
             Constraint::Length(8), // Big Timer Box
-            Constraint::Min(5),    // Zen Tree & Motivation
+            Constraint::Length(5), // Visualizador de música
+            Constraint::Min(5),    // Zen Tree & Motivación
             Constraint::Length(3), // Footer
         ])
         .split(size);
@@ -183,42 +184,63 @@ fn draw_active_session(f: &mut Frame, app: &App, theme: &Theme, size: Rect) {
         .alignment(Alignment::Center);
     f.render_widget(timer_box, chunks[1]);
 
-    // 3. Middle Section: árbol zen a la izquierda, quote motivacional a la derecha
+    // 3. Visualizador de música — misma lógica que en el config screen
+    draw_visualizer(f, app, theme, chunks[2]);
+
+    // 4. Middle Section: árbol zen a la izquierda, quote motivacional a la derecha
     let mid_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Percentage(40), // Tree Companion
             Constraint::Percentage(60), // Motivating scroll
         ])
-        .split(chunks[2]);
+        .split(chunks[3]);
 
-    // Left: el árbol zen — crece con cada sesión completada, chido sistema
+    // animación del árbol: crece de etapa 1 hasta la etapa actual, luego se queda
+    // 20 ticks/stage = 1 segundo por etapa; HOLD_TICKS = 3 segundos en la etapa final antes de reiniciar
     let zen_tree = app.db.get_zen_tree().unwrap();
-    let tree_text = vec![
-        Line::from(""),
-        Line::from(Span::styled(
-            zen_tree.ascii_art(),
+    let current_stage = zen_tree.stage.max(1) as usize;
+    const TICKS_PER_STAGE: usize = 20;
+    const HOLD_TICKS: usize = 60;
+    let cycle_len = current_stage * TICKS_PER_STAGE + HOLD_TICKS;
+    let cycle_pos = app.music_scroll_ticks % cycle_len;
+    let animated_stage = if cycle_pos >= current_stage * TICKS_PER_STAGE {
+        current_stage
+    } else {
+        (cycle_pos / TICKS_PER_STAGE + 1).min(current_stage)
+    } as i32;
+
+    let tree_color = if animated_stage == zen_tree.stage {
+        theme.success
+    } else {
+        Color::Rgb(34, 120, 60) // verde más oscuro mientras crece
+    };
+
+    let art_str = crate::models::ZenTree::ascii_art_at_stage(animated_stage);
+    let mut tree_lines: Vec<Line> = vec![Line::from("")];
+    for art_line in art_str.lines() {
+        tree_lines.push(Line::from(Span::styled(
+            art_line.to_string(),
+            Style::default().fg(tree_color).add_modifier(Modifier::BOLD),
+        )));
+    }
+    tree_lines.push(Line::from(""));
+    tree_lines.push(Line::from(vec![
+        Span::styled("Companion Tree: ", Style::default().fg(theme.muted)),
+        Span::styled(
+            zen_tree.stage_name(),
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    tree_lines.push(Line::from(vec![
+        Span::styled("Growth: ", Style::default().fg(theme.muted)),
+        Span::styled(
+            format!("{} pts", zen_tree.growth),
             Style::default().fg(theme.success),
-        )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("Companion Tree: ", Style::default().fg(theme.muted)),
-            Span::styled(
-                zen_tree.stage_name(),
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("Growth: ", Style::default().fg(theme.muted)),
-            Span::styled(
-                format!("{} pts", zen_tree.growth),
-                Style::default().fg(theme.success),
-            ),
-        ]),
-    ];
-    let tree_box = Paragraph::new(tree_text)
+        ),
+    ]));
+
+    let tree_box = Paragraph::new(tree_lines)
         .block(
             Block::default()
                 .borders(Borders::ALL)
@@ -267,7 +289,8 @@ fn draw_config_screen(f: &mut Frame, app: &App, theme: &Theme, size: Rect) {
         .constraints([
             Constraint::Length(3), // Header
             Constraint::Length(7), // Pickers Layout
-            Constraint::Min(4),    // Information / Selected details
+            Constraint::Length(5), // Visualizador de música
+            Constraint::Min(4),    // Session Forecast
             Constraint::Length(3), // Help instructions footer
         ])
         .split(size);
@@ -589,7 +612,11 @@ fn draw_config_screen(f: &mut Frame, app: &App, theme: &Theme, size: Rect) {
             .border_style(Style::default().fg(theme.border))
             .title(" Session Forecast "),
     );
-    f.render_widget(details, chunks[2]);
+
+    // renderiza el visualizador entre los pickers y el Session Forecast
+    draw_visualizer(f, app, theme, chunks[2]);
+
+    f.render_widget(details, chunks[3]);
 
     // Footer instructions
     let footer_text = vec![
@@ -622,5 +649,94 @@ fn draw_config_screen(f: &mut Frame, app: &App, theme: &Theme, size: Rect) {
         ]),
     ];
     let footer = Paragraph::new(footer_text).alignment(Alignment::Center);
-    f.render_widget(footer, chunks[3]);
+    f.render_widget(footer, chunks[4]);
+}
+
+// barras de espectro FFT en tiempo real — datos reales del audio local, animación sutil si no hay
+fn draw_visualizer(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    use crate::audio::PlaybackStatus;
+    use crate::audio::spectrum::NUM_BARS;
+
+    let status = app.audio_player.get_state().status;
+    let spectrum = app.audio_player.get_spectrum();
+    let t = app.music_scroll_ticks as f32;
+
+    // caracteres de bloque Unicode de menor a mayor altura
+    const BAR_CHARS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+    // si hay señal real (local FFT o captura del sistema), úsala — si no, animación de idle
+    let has_signal = spectrum.iter().any(|&v| v > 0.015);
+
+    let bar_spans: Vec<Span> = (0..NUM_BARS)
+        .map(|i| {
+            let height = if has_signal {
+                // datos reales: soundscape local vía SpectrumSource o MPRIS vía captura del monitor
+                match status {
+                    PlaybackStatus::Paused => spectrum[i].max(0.04),
+                    _ => spectrum[i],
+                }
+            } else {
+                // animación de idle cuando no hay señal de audio en el sistema
+                match status {
+                    PlaybackStatus::Playing => {
+                        let h = 0.5
+                            + 0.30 * f32::sin(t * 0.07 + i as f32 * 0.31)
+                            + 0.20 * f32::sin(t * 0.11 + i as f32 * 0.53)
+                            + 0.10 * f32::sin(t * 0.19 + i as f32 * 0.17);
+                        h.clamp(0.0, 1.0)
+                    }
+                    PlaybackStatus::Paused => 0.38,
+                    PlaybackStatus::Stopped => {
+                        let h = 0.10
+                            + 0.05 * f32::sin(t * 0.03 + i as f32 * 0.31)
+                            + 0.03 * f32::sin(t * 0.05 + i as f32 * 0.53);
+                        h.clamp(0.0, 1.0)
+                    }
+                }
+            };
+
+            let char_idx = ((height * 7.99) as usize).min(7);
+            let bar_char = BAR_CHARS[char_idx];
+
+            // gradiente de color según la altura: bajo→muted, medio→primary, alto→warning
+            let color = if height < 0.35 {
+                theme.muted
+            } else if height < 0.72 {
+                theme.primary
+            } else {
+                theme.warning
+            };
+
+            Span::styled(
+                format!("{} ", bar_char),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            )
+        })
+        .collect();
+
+    let title_str = match status {
+        PlaybackStatus::Playing => " ♪ Soundscape Visualizer ",
+        PlaybackStatus::Paused => " ⏸ Soundscape Visualizer ",
+        PlaybackStatus::Stopped => " ○ Soundscape Visualizer ",
+    };
+    let title_color = match status {
+        PlaybackStatus::Playing => theme.primary,
+        PlaybackStatus::Paused => theme.warning,
+        PlaybackStatus::Stopped => theme.muted,
+    };
+
+    let vis_text = vec![Line::from(""), Line::from(bar_spans)];
+    let vis = Paragraph::new(vis_text)
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(title_color))
+                .title(Span::styled(
+                    title_str,
+                    Style::default().fg(title_color).add_modifier(Modifier::BOLD),
+                )),
+        );
+    f.render_widget(vis, area);
 }

--- a/src/screens/soundscapes.rs
+++ b/src/screens/soundscapes.rs
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// screens/soundscapes.rs — la pantalla del reproductor de soundscapes
+// screens/soundscapes.rs — pantalla del reproductor: soundscapes + Media Player MPRIS
 // ─────────────────────────────────────────────────────────────────────────────
 use crate::app::App;
 use crate::audio::{PlaybackStatus, SOUNDSCAPES};
@@ -24,57 +24,41 @@ pub fn draw(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     let is_playing = player_state.status == PlaybackStatus::Playing;
     let playing_name = player_state.current_soundscape.clone();
 
-    // LEFT PANEL: Soundscapes list
+    // LEFT PANEL: lista de soundscapes
     let mut list_items = Vec::new();
     for (idx, sc) in SOUNDSCAPES.iter().enumerate() {
         let is_selected = idx == app.selected_soundscape_idx;
         let is_active_playing = is_playing && playing_name == sc.name;
 
         let marker = if is_selected { " -> " } else { "   " };
-
-        let play_icon = if is_active_playing {
-            " > ".to_string()
-        } else {
-            "   ".to_string()
-        };
+        let play_icon = if is_active_playing { " > ".to_string() } else { "   ".to_string() };
 
         let name_style = if is_selected {
-            Style::default()
-                .fg(theme.warning)
-                .add_modifier(Modifier::BOLD)
+            Style::default().fg(theme.warning).add_modifier(Modifier::BOLD)
         } else if is_active_playing {
-            Style::default()
-                .fg(accent_color)
-                .add_modifier(Modifier::BOLD)
+            Style::default().fg(accent_color).add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
         };
 
         let row_title = Line::from(vec![
             Span::styled(marker, Style::default().fg(theme.warning)),
-            Span::styled(
-                play_icon,
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled(play_icon, Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
             Span::styled(sc.name, name_style),
         ]);
-
         let desc_span = Span::styled(
             format!("      {}", sc.description),
             Style::default().fg(theme.muted),
         );
         let bonus_span = Span::styled(
             format!("      RPG Bonus: {}", sc.bonus),
-            Style::default().fg(Color::Rgb(16, 185, 129)), // Sleek emerald green
+            Style::default().fg(Color::Rgb(16, 185, 129)),
         );
-
         list_items.push(ListItem::new(vec![
             row_title,
             Line::from(desc_span),
             Line::from(bonus_span),
-            Line::from(""), // spacing
+            Line::from(""),
         ]));
     }
 
@@ -85,14 +69,29 @@ pub fn draw(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             .border_style(Style::default().fg(accent_color))
             .title(Span::styled(
                 " Music ",
-                Style::default()
-                    .fg(theme.warning)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
             )),
     );
     f.render_widget(list, chunks[0]);
 
-    // RIGHT PANEL: Status details & Help control hints
+    // RIGHT PANEL — cambia según si Media Player está seleccionado o no
+    if SOUNDSCAPES[app.selected_soundscape_idx].name == "Media Player" {
+        draw_mpris_panel(f, app, theme, chunks[1]);
+    } else {
+        draw_audio_control_panel(f, app, theme, chunks[1], &player_state, &playing_name);
+    }
+}
+
+fn draw_audio_control_panel(
+    f: &mut Frame,
+    _app: &App,
+    theme: &Theme,
+    area: Rect,
+    player_state: &crate::audio::state::AudioState,
+    playing_name: &str,
+) {
+    let accent_color = theme.primary;
+
     let vol_bar_width = 15;
     let filled_segments = (player_state.volume * vol_bar_width as f32).round() as usize;
     let vol_bar = format!(
@@ -107,14 +106,9 @@ pub fn draw(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         PlaybackStatus::Paused => "PAUSED",
         PlaybackStatus::Stopped => "STOPPED",
     };
-
     let status_style = match player_state.status {
-        PlaybackStatus::Playing => Style::default()
-            .fg(theme.success)
-            .add_modifier(Modifier::BOLD),
-        PlaybackStatus::Paused => Style::default()
-            .fg(theme.warning)
-            .add_modifier(Modifier::BOLD),
+        PlaybackStatus::Playing => Style::default().fg(theme.success).add_modifier(Modifier::BOLD),
+        PlaybackStatus::Paused => Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
         PlaybackStatus::Stopped => Style::default().fg(theme.muted),
     };
 
@@ -127,21 +121,14 @@ pub fn draw(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         Line::from(""),
         Line::from(vec![
             Span::styled("   Volume:      ", Style::default().fg(theme.muted)),
-            Span::styled(
-                vol_bar,
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled(vol_bar, Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
         ]),
         Line::from(""),
         Line::from(vec![
             Span::styled("   Atmosphere:  ", Style::default().fg(theme.muted)),
             Span::styled(
-                playing_name.clone(),
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
+                playing_name.to_string(),
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
             ),
         ]),
         Line::from(""),
@@ -149,87 +136,35 @@ pub fn draw(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             "   [Playback Keyboard Controls]",
-            Style::default()
-                .fg(theme.warning)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(vec![
-            Span::styled(
-                "     Enter   ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " Play selected atmosphere",
-                Style::default().fg(theme.text),
-            ),
+            Span::styled("     Enter   ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Play selected atmosphere", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
-            Span::styled(
-                "     p       ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " Pause / Resume current audio",
-                Style::default().fg(theme.text),
-            ),
+            Span::styled("     p       ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Pause / Resume current audio", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
-            Span::styled(
-                "     s       ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " Stop / Mute current playback",
-                Style::default().fg(theme.text),
-            ),
+            Span::styled("     s       ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Stop / Mute current playback", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
-            Span::styled(
-                "     n       ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " Cycle to next track",
-                Style::default().fg(theme.text),
-            ),
+            Span::styled("     n       ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Cycle to next track", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
-            Span::styled(
-                "     + / -   ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " Increase / Decrease volume",
-                Style::default().fg(theme.text),
-            ),
+            Span::styled("     + / -   ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Increase / Decrease volume", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
-            Span::styled(
-                "     *       ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("     *       ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
             Span::styled(" Reset volume to 50%", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
-            Span::styled(
-                "     f       ",
-                Style::default()
-                    .fg(accent_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("     f       ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
             Span::styled(" Change local music folder path", Style::default().fg(theme.text)),
         ]),
     ];
@@ -241,11 +176,101 @@ pub fn draw(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             .border_style(Style::default().fg(accent_color))
             .title(Span::styled(
                 " Audio Control Panel ",
-                Style::default()
-                    .fg(theme.warning)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
             )),
     );
-    f.render_widget(right_panel, chunks[1]);
+    f.render_widget(right_panel, area);
+}
 
+fn draw_mpris_panel(f: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let accent_color = theme.primary;
+
+    let (status_icon, track_line, artist_line, player_line, status_color) =
+        match &app.mpris_now_playing {
+            Some(np) => {
+                let icon = if np.is_playing { "▶" } else { "⏸" };
+                let color = if np.is_playing {
+                    Color::Rgb(30, 215, 96)
+                } else {
+                    theme.warning
+                };
+                let player_display = {
+                    let mut p = np.player.clone();
+                    if let Some(c) = p.get_mut(0..1) {
+                        c.make_ascii_uppercase();
+                    }
+                    p
+                };
+                (
+                    icon,
+                    format!("  {} {}", icon, np.title),
+                    format!("     by {}", np.artist),
+                    format!("     via {}", player_display),
+                    color,
+                )
+            }
+            None => (
+                "—",
+                "  No media player detected".to_string(),
+                "  Open Spotify, VLC, or any".to_string(),
+                "  MPRIS-compatible player".to_string(),
+                theme.muted,
+            ),
+        };
+
+    let _ = status_icon; // usado solo para construir track_line
+
+    let text = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            track_line,
+            Style::default().fg(status_color).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(artist_line, Style::default().fg(theme.text))),
+        Line::from(Span::styled(player_line, Style::default().fg(theme.muted))),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ──────────────────────────────",
+            Style::default().fg(theme.border),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Works with any MPRIS player:",
+            Style::default().fg(theme.muted),
+        )),
+        Line::from(Span::styled(
+            "  Spotify, VLC, Rhythmbox, mpv...",
+            Style::default().fg(theme.muted),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ──────────────────────────────",
+            Style::default().fg(theme.border),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Enter / p  ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Play / Pause", Style::default().fg(theme.text)),
+        ]),
+        Line::from(vec![
+            Span::styled("  n          ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Next track", Style::default().fg(theme.text)),
+        ]),
+        Line::from(vec![
+            Span::styled("  b          ", Style::default().fg(accent_color).add_modifier(Modifier::BOLD)),
+            Span::styled(" Previous track", Style::default().fg(theme.text)),
+        ]),
+    ];
+
+    let panel = Paragraph::new(text).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(accent_color))
+            .title(Span::styled(
+                " Media Player (MPRIS) ",
+                Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
+            )),
+    );
+    f.render_widget(panel, area);
 }


### PR DESCRIPTION
// Changes in this version
  ✓  Music visualizer now shows real audio frequencies
  ✓  Works with any system audio player — Spotify, VLC, mpv, anything
  ✓  Local soundscapes (Lo-Fi, Rain, Forest…) also show real spectrum
  ✓  Bars respond instantly; fall off gradually (VU meter behavior)
  ✓  Search navigates to the exact note, task, step, or milestone
  ✓  Results ranked by relevance — title match beats content match
  ✓  Search now covers steps and milestones
  ✓  Press / from anywhere to open search instantly
  ✓  Footer nav shows the active screen name with class color highlight
  ✓  Ambient effects now accessible from the Command Palette (Ctrl+P)
  –  The bars still cannot play the music. This is a feature, not a limitation.